### PR TITLE
reconstruct to support cloud functions well

### DIFF
--- a/template/build/webpack.main.conf.js
+++ b/template/build/webpack.main.conf.js
@@ -1,8 +1,5 @@
 var path = require('path')
 var merge = require('webpack-merge')
-{% if mode === "wx" %}
-var CopyWebpackPlugin = require('copy-webpack-plugin')
-{% endif %}
 var baseWebpackConfig = require('./webpack.base.conf')
 var mainSubDir = '{% if isPlugin %}miniprogram{% endif %}'
 
@@ -22,16 +19,6 @@ module.exports = merge(baseWebpackConfig, {
   output: {
     path: resolveDist()
   },
-  {% if mode === "wx" %}
-  plugins: [
-    new CopyWebpackPlugin([
-      {
-        from: path.resolve(__dirname, '../static/project.config.json'),
-        to: path.resolve(__dirname, '../dist/project.config.json')
-      }
-    ])
-  ],
-  {% endif %}
   resolve: {
     modules: [resolveSrc()]
   }

--- a/template/package.json
+++ b/template/package.json
@@ -14,13 +14,13 @@
   "license": "ISC",
   "dependencies": {
     {% if mode === 'wx' %}
-    "@mpxjs/core": "^1.0.0"
+    "@mpxjs/core": "^1.0.5"
     {% else %}
     "@mpxjs/core-ant": "^1.0.0"
     {% endif %}
   },
   "devDependencies": {
-    "@mpxjs/webpack-plugin": "^1.0.0",
+    "@mpxjs/webpack-plugin": "^1.0.10",
     "@mpxjs/url-loader": "^1.0.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
@@ -29,9 +29,6 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
     "chalk": "^2.3.2",
-    {% if mode === "wx" %}
-    "copy-webpack-plugin": "^4.5.1",
-    {% endif %}
     "css-loader": "^0.28.10",
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",

--- a/template/project.config.json
+++ b/template/project.config.json
@@ -2,6 +2,7 @@
   {% if isPlugin %}
   "miniprogramRoot": "./miniprogram",
   "pluginRoot": "./plugin",
+  "miniprogramRoot": "dist/",
   "compileType": "plugin",
   {% else %}
   "compileType": "miniprogram",

--- a/template/project.config.json
+++ b/template/project.config.json
@@ -1,7 +1,7 @@
 {
   {% if isPlugin %}
-  "miniprogramRoot": "./miniprogram",
-  "pluginRoot": "./plugin",
+  "miniprogramRoot": "./dist/miniprogram",
+  "pluginRoot": "./dist/plugin",
   "compileType": "plugin",
   {% else %}
   "miniprogramRoot": "dist/",

--- a/template/project.config.json
+++ b/template/project.config.json
@@ -2,9 +2,9 @@
   {% if isPlugin %}
   "miniprogramRoot": "./miniprogram",
   "pluginRoot": "./plugin",
-  "miniprogramRoot": "dist/",
   "compileType": "plugin",
   {% else %}
+  "miniprogramRoot": "dist/",
   "compileType": "miniprogram",
   {% endif %}
   "setting": {


### PR DESCRIPTION
通过在project.config.json里指定miniprogramRoot为dist文件夹，避免copy文件，且更易在微信开发者工具里反向修改，以及更好地允许用户使用云开发云函数等功能（他们需要在project.config中指定一些目录）