### PR TITLE
Support Typescript ESLint

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -16,5 +16,19 @@ module.exports = {
     'getApp': true,
     'App': true,
     '__mpx_mode__': true
-  }
+  },
+  {% if tsSupport %}
+  overrides: [
+    {
+      files: ["**/*.ts"],
+      parser: "@typescript-eslint/parser",
+      extends: [
+        "standard",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+      ],
+      plugins: ["@typescript-eslint"],
+    },
+  ],
+  {% endif %}
 }

--- a/template/package.json
+++ b/template/package.json
@@ -51,11 +51,11 @@
     {% if needEslint %}
     "eslint-loader": "^2.1.1",
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.10.0",
+    "eslint": "^6.0.0",
     "eslint-config-babel": "^8.0.2",
     "eslint-config-standard": "^12.0.0",
     "eslint-friendly-formatter": "^4.0.1",
-    "eslint-plugin-html": "^5.0.0",
+    "eslint-plugin-html": "^6.0.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-local-rules": "^0.1.0",
     "eslint-plugin-node": "^8.0.0",
@@ -66,6 +66,8 @@
     {% if tsSupport %}
     "ts-loader": "^6.0.0",
     "typescript": "^3.5.0",
+    "@typescript-eslint/eslint-plugin": "^2.27.0",
+    "@typescript-eslint/parser": "^2.27.0",
     {% endif %}
     {% if babel7Support %}
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
选择 ts 开发后，eslint 配置文件没设置对应的 parser 和 规则。

**说明**
重写 **/*.ts 的文件规则。
由于 eslint 6.0 之后 overrides 才支持 extends ，所以升级了两个依赖。