### PR TITLE
* 统一 babel 进行转译

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "esnext",
+    "module": "esnext",
     "allowJs": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
     "lib": [
+      "esnext",
       "dom",
       "es6",
       "dom.iterable"

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -10,7 +10,6 @@
     "lib": [
       "esnext",
       "dom",
-      "es6",
       "dom.iterable"
     ]
   },


### PR DESCRIPTION
原 tsconfig.js 配置中的 target = es6。如果项目中 ts 和 js 混用，js使用babel转译，ts使用了tsc 的转译。导致两者 polyfill 不一致，代码量增多。

由于 ts 的 polyfill 都是直接在代码中插入 runtime代码，无法像 babel 那样经过 transform-runtime 插件处理，ts 的文件明显比 js 冗余代码更多。

所以将ts的target设置为 esnext(几乎直出)，统一交由babel进行 polyfill 处理。

TS 处理 / target : es6
[Playground Link](https://www.typescriptlang.org/en/play?target=2#code/AQMwrgdgxgLglgewsAhgZwJ7QOIFMYAqcAtrgBQCUA3gFDD3ABO+YjyEuA7sAAqMLE4acszQIANgDdcAXgB8tBkuDDCJXAjAwyleYuUHRE6WQAiKGLgB0EBJ0oU6B4AF8ANAFYADD8dKXji40NOhYUKCQsIjIAOb4RKSU+vRQSGgwTLhowDKonChwGaE48eqUTilpEtbiCDFkooFAA)

Babel 处理 
[Babel Try it out!](https://babeljs.io/repl#?browsers=chrome%20%3E%3D53%2C%20ios%20%3E%3D%208&build=&builtIns=usage&spec=false&loose=true&code_lz=GYVwdgxgLglg9mABAQwM4E9IHECmUAqMAtjgBQCUA3gFCKIBOeI9SYOA7ogAr1xEyoyjVHAA2ANxwBeAHw06CxIILEccEFFIVZ8xXuFjJpACLIoOAHRg47CuVp6AvgBoArAAZP9uo_uPq1GiYEIigkLAIiADmeIQkFLoQCKhQDDioiFIo7MgwqUHYsaoUDklgIqKWonBRpMJ-1DEq8eRAA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=env%2Cenv&prettier=false&targets=&version=7.9.0&externalPlugins=%40babel%2Fplugin-proposal-object-rest-spread%407.8.3%2C%40babel%2Fplugin-syntax-dynamic-import%407.8.3%2C%40babel%2Fplugin-transform-runtime%407.9.0%2C%40babel%2Fplugin-transform-async-to-generator%407.8.3)