### PR TITLE
build(babel): 增加  transform-async-to-generator 插件

### DIFF
--- a/template/babel.config.json
+++ b/template/babel.config.json
@@ -21,6 +21,7 @@
     "@babel/proposal-throw-expressions",
     "@babel/syntax-dynamic-import",
     "@babel/syntax-import-meta",
+    "@babel/transform-async-to-generator",
     "@babel/transform-runtime"
   ],
   "env": {

--- a/template/package.json
+++ b/template/package.json
@@ -96,6 +96,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.0",
+    "@babel/plugin-transform-async-to-generator": "^7.8.3",
     {% else %}
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",


### PR DESCRIPTION
未使用 async-to-generator 时，有可能导致 async 的方法 this 指向出错。表现在编译过后的代码中this指向到了regeneratorRuntime 的方法内

未使用前：

留意 `_this6`

![image](https://user-images.githubusercontent.com/3240259/80670217-e3f0ce80-8ad8-11ea-9b77-cd2a85342387.png)


