### PR TITLE
add npm7 multi-mode support

### DIFF
--- a/template/build/build.js
+++ b/template/build/build.js
@@ -16,6 +16,16 @@ program
 const npmConfigArgvOriginal = (process.env.npm_config_argv && JSON.parse(process.env.npm_config_argv).original) || []
 const modeArr = npmConfigArgvOriginal.filter(item => typeof item === 'string').map(item => item.replace('--', '')).filter(item => supportedModes.includes(item))
 
+// 暂时兼容npm7的写法
+if (!npmConfigArgvOriginal.length) {
+  const env = process.env
+  supportedCrossMode.forEach(key => {
+    if (env[`npm_config_${key}`] === 'true') {
+      modeArr.push(key)
+    }
+  })
+}
+
 if (!modeArr.length) modeArr.push(userConf.srcMode)
 
 let webpackConfs = []


### PR DESCRIPTION
use the easiest way to support npm7 multi-mode . fix `npm run watch --ali` not use.