### PR TITLE
fix: 修复postcss配置

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -77,6 +77,7 @@
     "typescript": "^4.1.2",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",
+    "autoprefixer": "^10.2.6",
     {% if babel7Support %}
     "@babel/core": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.10.4",

--- a/template/postcss.config.js
+++ b/template/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: [
-    require('autoprefixer')({ remove: false })
-
+    'autoprefixer': { remove: false },
   ]
 }


### PR DESCRIPTION
`(Emitted value instead of an instance of Error) Error loading PostCSS config: Cannot find module 'autoprefixer'`

`(Emitted value instead of an instance of Error) Error loading PostCSS config: Invalid PostCSS Plugin found: [0]`

ref: [https://stackoverflow.com/questions/61104498/typeerror-invalid-postcss-plugin-found-at-plugins0](https://stackoverflow.com/questions/61104498/typeerror-invalid-postcss-plugin-found-at-plugins0)